### PR TITLE
Potential fix for code scanning alert no. 73: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/eliakimp/juice-shop/security/code-scanning/73](https://github.com/eliakimp/juice-shop/security/code-scanning/73)

The best way to fix this vulnerability is to entirely avoid interpolating unsanitized user input in a MongoDB `$where` clause. Instead, use parameterized queries or direct field matching where possible. For this case, since the intent is to find an order by `orderId`, replace the `$where` clause with a standard MongoDB query: `{ orderId: id }`. This avoids code execution and prevents injection vulnerabilities altogether. Edit file `routes/trackOrder.ts` line 18, replacing the `$where` clause with a direct query. No additional imports or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
